### PR TITLE
chore: using Libdl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TextWrap = "b718987f-49a8-5099-9789-dcd902bef87d"
 Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 spglib_jll = "ac4a9f1e-bdb2-5204-990c-47c8b2f70d4e"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
 ArgParse = "1.1"

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -8,6 +8,7 @@ precompile(Tuple{getfield(TextWrap, Symbol("#wrap##kw")), NamedTuple{(:break_lon
 using Random
 using Logging
 using Statistics
+using Libdl
 
 precompile(Tuple{typeof(Base.isassigned), Core.SimpleVector, Int64})
 precompile(Tuple{typeof(Random.shuffle!), Random.MersenneTwister, Array{Symbol, 1}})
@@ -20,7 +21,7 @@ precompile(Tuple{getfield(Core, Symbol("#Type##kw")), NamedTuple{(:libc, :compil
 precompile(Tuple{Type{Base.Pair{A, B} where B where A}, Pkg.BinaryPlatforms.FreeBSD, Base.Dict{String, Any}})
 precompile(Tuple{typeof(Base.setindex!), Base.Dict{Pkg.BinaryPlatforms.Platform, Base.Dict{String, Any}}, Base.Dict{String, Any}, Pkg.BinaryPlatforms.FreeBSD})
 precompile(Tuple{getfield(Pkg.Artifacts, Symbol("#ensure_artifact_installed##kw")), Any, typeof(Pkg.Artifacts.ensure_artifact_installed), String, Base.Dict{K, V} where V where K, String})
-precompile(Tuple{typeof(Base.Libc.Libdl.dlopen), String})
+precompile(Tuple{typeof(Libdl.dlopen), String})
 precompile(Tuple{typeof(Chemfiles._warning_callback_adaptator), Ptr{UInt8}})
 precompile(Tuple{typeof(Chemfiles.__init__)})
 precompile(Tuple{getfield(Base, Symbol("#@__DIR__")), LineNumberNode, Module})


### PR DESCRIPTION
Great work, thanks for the effort, will be useful!

this seems to be needed for Julia > 0.7. At least i needed it to get started with Julia 1.5. 

Unfortunately, I run into 

```
julia> net = CrystalNet(crystal);
ERROR: MethodError: no method matching prod(::Type{BigFloat}, ::Array{Float64,1}; init=1.0)
Closest candidates are:
  prod(::Any, ::AbstractArray; dims) at reducedim.jl:723 got unsupported keyword argument "init"
```

I guess (https://github.com/coudertlab/CrystalNets.jl/blob/2cc25ad7d536acca339eab819dda3ff63ef557b3/src/specialsolver.jl#L238) you use the Julia 1.6-dev? Could you maybe update the dependencies? 