### PR TITLE
chore: updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Currently only works for 3-periodic nets.
 ## <a name="installation"></a>Installation
 
 Install julia and add this module either from a console with:
+
 ```bash
 julia -e 'import Pkg; Pkg.add(url="https://github.com/coudertlab/CrystalNets.jl")'
 ```
+
 or from the julia REPL by typing
+
 ```
 ] add https://github.com/coudertlab/CrystalNets.jl
 ```
@@ -24,6 +27,7 @@ or from the julia REPL by typing
 CrystalNets can read any chemical file parseable by [Chemfiles](https://chemfiles.org/chemfiles/latest/formats.html#list-of-supported-formats). In order to be correctly interpreted, the file should only contain information about the crystal (or crystalline framework), which must be a connected 3-periodic structure.
 
 Parsing can be done with the dedicated function `parse_chemfile`. A parsed file will be stored as an intermediate object of type `Crystal`, as in the following session:
+
 ```julia
 julia> using CrystalNets
 
@@ -31,26 +35,31 @@ julia> crystal = parse_chemfile("/path/to/diamond.cif");
 ```
 
 `Crystal` objects retain information on the input geometry, such as the cell and the positions. These are irrelevant to the elucidation of the topological structure however, where only the underlying net matters. A `Crystal` must thus be converted to a net, using the type `CrystalNet`:
+
 ```julia
 julia> net = CrystalNet(crystal);
 ```
 
 Finally, the topological genome can be extracted with the dedicated `topological_genome` function, which yields a [`PeriodicGraph`](https://github.com/Liozou/PeriodicGraphs.jl) that uniquely represents the net. Its string version is the dense genome that is characteristic of the net: for instance, with the diamond net:
+
 ```julia
 julia> string(topological_genome(net))
 "3 1 2 0 0 0 1 2 0 0 1 1 2 0 1 0 1 2 1 0 0"
 ```
 
 This string can be fed to the `reckognize_topology` function in order to determine the RCSR name of the topology:
+
 ```julia
 julia> reckognize_topology("3 1 2 0 0 0 1 2 0 0 1 1 2 0 1 0 1 2 1 0 0")
 "dia"
 ```
 
 All these steps can be summarised by executing
+
 ```julia
 julia> reckognize_topology(topological_genome(CrystalNet(parse_chemfile(FILE))))
 ```
+
 where `FILE` is the path to the crystal in a reckognizable chemical file format.
 
 ## Use as an executable
@@ -58,6 +67,7 @@ where `FILE` is the path to the crystal in a reckognizable chemical file format.
 ### Without additional installation
 
 Once installed following the [Installation](#installation) section, the following script will yield the path to the local installation of the module:
+
 ```julia
 julia> using CrystalNets
 
@@ -70,6 +80,7 @@ julia> normpath(path, "..", "..")
 ```
 
 Once you have this path, execute the CrystalNets.jl file using the CrystalNet directory as project from a shell with julia. For instance:
+
 ```
 $ julia --project=/the/path/to/CrystalNets/ /the/path/to/CrystalNets/src/CrystalNets.jl
 Missing a CRYSTAL_FILE.
@@ -83,15 +94,14 @@ tbo
 ### Full installation
 
 To create a proper executable (which will execute faster than the previous option), follow the previous [Installation](#installation) section and then run the following julia script after changing the `INSTALLATION_PATH` variable to the location where the CrystalNets executable will be installed. Note that this requires the [PackageCompiler](https://github.com/JuliaLang/PackageCompiler.jl/) module, which can be installed by replacing "CrystalNets" with "PackageCompiler" in the [Installation](#installation) section.
+
 ```julia
 INSTALLATION_PATH = "/fill/with/installation/path"
-
-mkpath(INSTALLATION_PATH)
 
 using PackageCompiler
 using CrystalNets
 
-root = normpath(pathof(CrystalNets), "..")
+root = normpath(pathof(CrystalNets), "..", "..")
 
 create_app(root, INSTALLATION_PATH; precompile_statements_file=abspath(root, "src", "precompile.jl"))
 ```
@@ -99,10 +109,13 @@ create_app(root, INSTALLATION_PATH; precompile_statements_file=abspath(root, "sr
 The executable will be located in the "bin" subdirectory of the specified `INSTALLATION_PATH`, under the name "CrystalNets".
 
 The executable can then simply be used on a chemical file:
+
 ```
 $ CrystalNets /path/to/diamond.cif
 ```
+
 will yield
+
 ```
 dia
 ```


### PR DESCRIPTION
sorry for the changes due to the linter. 

there are only two real changes in the readme, both are in the script for the `create_app`. 
- I think `mkpath` is not needed 
- And the `root` path had a typo