### PR TITLE
Fix Base.hash to use only the two-arg method

### DIFF
--- a/src/Modulos.jl
+++ b/src/Modulos.jl
@@ -22,7 +22,7 @@ end
 
 (::Type{T})(x::Modulo) where {T<:Integer} = T(x.value)
 
-function hash(x::Modulo{p}, h::UInt64=UInt64(0)) where p
+function hash(x::Modulo{p}, h::UInt) where p
     hash(Integer(x), hash(p, h))
 end
 


### PR DESCRIPTION
Generated as part of an ecosystem-wide audit for one-arg hash methods.

`Base.hash` should only be extended via the two-arg method `hash(x, h::UInt)`.
Defining a one-arg `hash(x)` method, or giving the second argument a default
value, can lead to correctness bugs (hash contract violations when the seed
differs from the hard-coded default) and invalidation-related performance
issues. This is particularly necessary for Julia 1.13+ where the default hash
seed value will change.

This PR was generated with the assistance of generative AI.